### PR TITLE
Fix: fps adaptation

### DIFF
--- a/src/live_portrait_pipeline.py
+++ b/src/live_portrait_pipeline.py
@@ -174,17 +174,18 @@ class LivePortraitPipeline(object):
 
         mkdir(args.output_dir)
         wfp_concat = None
+        video_fps = cv2.VideoCapture(args.driving_info).get(cv2.CAP_PROP_FPS)
         if is_video(args.driving_info):
             frames_concatenated = concat_frames(I_p_lst, driving_rgb_lst, img_crop_256x256)
             # save (driving frames, source image, drived frames) result
             wfp_concat = osp.join(args.output_dir, f'{basename(args.source_image)}--{basename(args.driving_info)}_concat.mp4')
-            images2video(frames_concatenated, wfp=wfp_concat)
+            images2video(frames_concatenated, wfp=wfp_concat, fps=video_fps)
 
         # save drived result
         wfp = osp.join(args.output_dir, f'{basename(args.source_image)}--{basename(args.driving_info)}.mp4')
         if inference_cfg.flag_pasteback:
-            images2video(I_p_paste_lst, wfp=wfp)
+            images2video(I_p_paste_lst, wfp=wfp, fps=video_fps)
         else:
-            images2video(I_p_lst, wfp=wfp)
+            images2video(I_p_lst, wfp=wfp, fps=video_fps)
 
         return wfp, wfp_concat


### PR DESCRIPTION
I found that the current code can only handle 30fps videos well. If the fps is relatively low, the generated video will lose many seconds and the action speed will be too fast.