### PR TITLE
replace the get_fps with a stabler version

### DIFF
--- a/src/utils/video.py
+++ b/src/utils/video.py
@@ -141,9 +141,7 @@ def change_video_fps(input_file, output_file, fps=20, codec='libx264', crf=5):
 
 def get_fps(filepath, default_fps=25):
     try:
-        probe = ffmpeg.probe(filepath)
-        video_stream = next((stream for stream in probe['streams'] if stream['codec_type'] == 'video'), None)
-        fps = eval(video_stream['avg_frame_rate'])
+        fps = cv2.VideoCapture(filepath).get(cv2.CAP_PROP_FPS)
 
         if fps in (0, None):
             fps = default_fps


### PR DESCRIPTION
The current code may still have <module 'ffmpeg' has no attribute 'probe'> errors, and pip install ffmpeg-python can not stably solve the problem. If you install both ffmpeg and ffmpeg-python at the same time, this error will still appear and fps cannot be obtained properly.

A feasible solution is:
pip uninstall ffmpeg
pip uninstall ffmpeg-python
then:
pip install ffmpeg-python

Or use OpenCV to obtain it, just like the code I updated.