### PR TITLE
Poorman's optimizations to save RAM usage

### DIFF
--- a/src/config/argument_config.py
+++ b/src/config/argument_config.py
@@ -17,6 +17,7 @@ class ArgumentConfig(PrintableConfig):
     source_image: Annotated[str, tyro.conf.arg(aliases=["-s"])] = make_abs_path('../../assets/examples/source/s6.jpg')  # path to the source portrait
     driving_info:  Annotated[str, tyro.conf.arg(aliases=["-d"])] = make_abs_path('../../assets/examples/driving/d0.mp4')  # path to driving video or template (.pkl format)
     output_dir: Annotated[str, tyro.conf.arg(aliases=["-o"])] = 'animations/'  # directory to save output video
+    lazy_loading: bool = False # load input images on demand one by one frame to minimize RAM usage
 
     ########## inference arguments ##########
     flag_use_half_precision: bool = True  # whether to use half precision (FP16). If black boxes appear, it might be due to GPU incompatibility; set to False.

--- a/src/live_portrait_pipeline.py
+++ b/src/live_portrait_pipeline.py
@@ -104,7 +104,7 @@ class LivePortraitPipeline(object):
                 log(f'The FPS of {args.driving_info} is: {output_fps}')
 
             log(f"Load video file (mp4 mov avi etc...): {args.driving_info}")
-            driving_rgb_lst = load_driving_info(args.driving_info)
+            driving_rgb_lst = load_driving_info(args.driving_info, lazy=args.lazy_loading)
 
             ######## make motion template ########
             log("Start making motion template...")

--- a/src/live_portrait_pipeline.py
+++ b/src/live_portrait_pipeline.py
@@ -220,7 +220,7 @@ class LivePortraitPipeline(object):
         # driving frame | source image | generation, or source image | generation
         frames_concatenated = concat_frames(driving_rgb_crop_256x256_lst, img_crop_256x256, I_p_lst)
         wfp_concat = osp.join(args.output_dir, f'{basename(args.source_image)}--{basename(args.driving_info)}_concat.mp4')
-        images2video(frames_concatenated, wfp=wfp_concat, fps=output_fps)
+        images2video(frames_concatenated, wfp=wfp_concat, fps=output_fps, frames_count=len(driving_rgb_crop_256x256_lst))
 
         if flag_has_audio:
             # final result with concact


### PR DESCRIPTION
- Driving video full frames not load entirely into RAM, instead load each frame on demand.
- Output frames generates and immediately writes to disk.
This optimizations minimizes RAM usage.