### PR TITLE
Fix: align the source frame and first driving frame, fix the bad case cause by misalign.

### DIFF
--- a/src/live_portrait_pipeline.py
+++ b/src/live_portrait_pipeline.py
@@ -256,12 +256,22 @@ class LivePortraitPipeline(object):
             x_s = self.live_portrait_wrapper.transform_keypoint(x_s_info)
 
             # let lip-open scalar to be 0 at first
+            # if flag_normalize_lip and inf_cfg.flag_relative_motion and source_lmk is not None:
+            #     c_d_lip_before_animation = [0.]
+            #     combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(c_d_lip_before_animation, source_lmk)
+            #     if combined_lip_ratio_tensor_before_animation[0][0] >= inf_cfg.lip_normalize_threshold:
+            #         lip_delta_before_animation = self.live_portrait_wrapper.retarget_lip(x_s, combined_lip_ratio_tensor_before_animation)
             if flag_normalize_lip and inf_cfg.flag_relative_motion and source_lmk is not None:
-                c_d_lip_before_animation = [0.]
-                combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(c_d_lip_before_animation, source_lmk)
-                if combined_lip_ratio_tensor_before_animation[0][0] >= inf_cfg.lip_normalize_threshold:
-                    lip_delta_before_animation = self.live_portrait_wrapper.retarget_lip(x_s, combined_lip_ratio_tensor_before_animation)
+                # c_d_lip_before_animation = [0.]
+                # combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(c_d_lip_before_animation, source_lmk)
+                c_d_lip_before_animation = driving_template_dct['c_lip_lst'][0]  
+                combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(
+                    c_d_lip_before_animation, 
+                    source_lmk
+                )
+                lip_delta_before_animation = self.live_portrait_wrapper.retarget_lip(x_s, combined_lip_ratio_tensor_before_animation)
 
+            
             if inf_cfg.flag_pasteback and inf_cfg.flag_do_crop and inf_cfg.flag_stitching:
                 mask_ori_float = prepare_paste_back(inf_cfg.mask_crop, crop_info['M_c2o'], dsize=(source_rgb_lst[0].shape[1], source_rgb_lst[0].shape[0]))
 
@@ -285,13 +295,22 @@ class LivePortraitPipeline(object):
                 x_s =x_s_info['x_s']
 
                 # let lip-open scalar to be 0 at first if the input is a video
+                # if flag_normalize_lip and inf_cfg.flag_relative_motion and source_lmk is not None:
+                #     c_d_lip_before_animation = [0.]
+                #     combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(c_d_lip_before_animation, source_lmk)
+                #     if combined_lip_ratio_tensor_before_animation[0][0] >= inf_cfg.lip_normalize_threshold:
+                #         lip_delta_before_animation = self.live_portrait_wrapper.retarget_lip(x_s, combined_lip_ratio_tensor_before_animation)
+                #     else:
+                #         lip_delta_before_animation = None
                 if flag_normalize_lip and inf_cfg.flag_relative_motion and source_lmk is not None:
-                    c_d_lip_before_animation = [0.]
-                    combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(c_d_lip_before_animation, source_lmk)
-                    if combined_lip_ratio_tensor_before_animation[0][0] >= inf_cfg.lip_normalize_threshold:
-                        lip_delta_before_animation = self.live_portrait_wrapper.retarget_lip(x_s, combined_lip_ratio_tensor_before_animation)
-                    else:
-                        lip_delta_before_animation = None
+                    # c_d_lip_before_animation = [0.]
+                    c_d_lip_before_animation = driving_template_dct['c_lip_lst'][0]  
+                    combined_lip_ratio_tensor_before_animation = self.live_portrait_wrapper.calc_combined_lip_ratio(
+                        c_d_lip_before_animation,
+                        source_lmk
+                    )
+                    lip_delta_before_animation = self.live_portrait_wrapper.retarget_lip(x_s, combined_lip_ratio_tensor_before_animation)
+
 
                 # let eye-open scalar to be the same as the first frame if the latter is eye-open state
                 if flag_source_video_eye_retargeting and source_lmk is not None:


### PR DESCRIPTION
## Problem Description:
- When use i2v, if the source frame is not align with the first driven video frame, it will raise bad case. For example, if the first frame is mouth-openning, and the first frame is mouth-close, when trying to use the driven-video drive the source frame, the result attemps to close mouth. This is a common issue.
## Workaround:
- Try to align the source frame to driven-video first frame. Base on the driven-video first frame's mouth ration, we can use the warpper function to warp the source mouth ot be same as the driven-video first frame.
- try to modify the code in https://github.com/KwaiVGI/LivePortrait/blob/aa749159bda43b458349bcd978c007d51ca6659e/src/live_portrait_pipeline.py#L259 and https://github.com/KwaiVGI/LivePortrait/blob/aa749159bda43b458349bcd978c007d51ca6659e/src/live_portrait_pipeline.py#L288
## Result comapre:
- When don't do normalize
https://github.com/user-attachments/assets/ecf28474-9383-4378-8771-22b75dab4c93
- Do normalized as modified
https://github.com/user-attachments/assets/cfc6f7d5-533e-4a54-a785-e4275ab73de8
- Do normalize as original, warp source base on mouth_ratio=0
https://github.com/user-attachments/assets/6a35bdeb-60ee-4376-bd9d-09275e0fb66b

## Summary
I am not'sure if this can be a workaround to break the limited in `Make sure the first frame of driving video is a frontal face with neutral expression.`  mentioned in https://github.com/KwaiVGI/LivePortrait?tab=readme-ov-file#driving-video-auto-cropping-.  
